### PR TITLE
Fix indentation of lists to be consistent

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,10 +4,7 @@
         url('assets/fonts/labmono-regular-web.woff') format('woff');
 }
 
-
-
 body {
-
 	font-family: 'Lab Mono', 'Courier', monospace;
 }
 
@@ -29,4 +26,17 @@ section.cover .cover-main > p:last-child a:last-child {
 
 section.cover ul {
 	max-width: none;
+}
+
+.markdown-section ul,
+.markdown-section ol {
+	padding-left: 0;
+}
+
+.markdown-section ul {
+	margin-left: -10px;
+}
+
+.markdown-section ul li {
+	padding-left: 10px;
 }


### PR DESCRIPTION
Tested on Chrome and Firefox.

Before:

![before](https://user-images.githubusercontent.com/2226144/82545589-914a8580-9b5f-11ea-9f17-bf68a600c855.png)

After:

![after](https://user-images.githubusercontent.com/2226144/82545601-94de0c80-9b5f-11ea-87ec-8bb5828adff3.png)